### PR TITLE
Copy the lack-of-category-featured for the 'Around the State' category to 'Mississippi Roundup' as well

### DIFF
--- a/wp-content/themes/mstoday/category-mississippi-roundup.php
+++ b/wp-content/themes/mstoday/category-mississippi-roundup.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Template for around the state category page.
+ * This removes the featured area for just this category,
+ * in the future we may want a more elegant way of doing this....
+ *
+ * This depends upon mstoday_remove_category_header_on_thi_one_specific_category in functions.php
+ * If the priority largo_category_archive_posts is registered with changes from 15 in largo/inc/taxonomies.php, then this template will no longer work.
+ *
+ * @package Largo
+ * @since 0.4
+ * @filter largo_partial_by_post_type
+ */
+get_header();
+
+global $tags, $paged, $post, $shown_ids;
+
+$title = single_cat_title( '', false );
+$description = category_description();
+$rss_link = get_category_feed_link( get_queried_object_id() );
+$posts_term = of_get_option( 'posts_term_plural', 'Stories' );
+$queried_object = get_queried_object();
+?>
+
+<div class="clearfix">
+	<header class="archive-background clearfix">
+		<a class="rss-link rss-subscribe-link" href="<?php echo $rss_link; ?>"><?php echo __( 'Subscribe', 'largo' ); ?> <i class="icon-rss"></i></a>
+		<h1 class="page-title"><?php echo $title; ?></h1>
+		<div class="archive-description"><?php echo $description; ?></div>
+	</header>
+</div>
+
+<div class="row-fluid clearfix">
+	<div class="stories span8" role="main" id="content">
+		
+	<?php 
+		do_action( 'largo_before_category_river' );
+		if ( have_posts() ) {
+			$counter = 1;
+			while ( have_posts() ) {
+				the_post();
+				$post_type = get_post_type();
+				$partial = largo_get_partial_by_post_type( 'archive', $post_type, 'archive' );
+				get_template_part( 'partials/content', 'archive' );
+				do_action( 'largo_loop_after_post_x', $counter, $context = 'archive' );
+				$counter++;
+			}
+			largo_content_nav( 'nav-below' );
+		}
+		do_action( 'largo_after_category_river' ); 
+	?>
+	</div>
+	<?php get_sidebar(); ?>
+</div>
+
+<?php get_footer();

--- a/wp-content/themes/mstoday/functions.php
+++ b/wp-content/themes/mstoday/functions.php
@@ -91,10 +91,15 @@ add_action( 'largo_loop_after_post_x', 'mstoday_interstitial', 10, 2 );
  */
 function mstoday_remove_category_header_on_this_one_specific_category() {
 	$qo = get_queried_object();
-	if ( is_main_query() && is_category() && $qo->slug === 'around-the-state' ) {
+	if ( is_main_query() && is_category() &&
+		( 'around-the-state' === $qo->slug || 'mississippi-roundup' === $qo->slug )
+	) {
 		remove_action( 'pre_get_posts', 'largo_category_archive_posts', 15 );
 	} else {
-		// put this back if it's not any of the above; we might need this perhaps maybe
+		// if the case is not any of the above, make sure that this is enabled
+		// because otherwise all other category pages will be messed up
+		//
+		// this may cause an issue if they ever check the box for hide_category_featured
 		add_action( 'pre_get_posts', 'largo_category_archive_posts', 15 );
 	}
 }


### PR DESCRIPTION
## Changes

- makes a new category template for "Mississippi Roundup" that disables the category featured header for this specific category
- removes largo's filter on posts returned for that as well
- corrects a comment on that filter
