### PR TITLE
copying over header.php from largo and removing <title> tag

### DIFF
--- a/wp-content/themes/mstoday/header.php
+++ b/wp-content/themes/mstoday/header.php
@@ -1,0 +1,120 @@
+<!DOCTYPE html>
+<!--[if lt IE 7]> <html <?php language_attributes(); ?> class="no-js ie6"> <![endif]-->
+<!--[if IE 7]>    <html <?php language_attributes(); ?> class="no-js ie7"> <![endif]-->
+<!--[if IE 8]>    <html <?php language_attributes(); ?> class="no-js ie8"> <![endif]-->
+<!--[if IE 9]>    <html <?php language_attributes(); ?> class="no-js ie9"> <![endif]-->
+<!--[if (gt IE 9)|!(IE)]><!--> <html <?php language_attributes(); ?> class="no-js"> <!--<![endif]-->
+<head>
+	<meta charset="<?php bloginfo( 'charset' ); ?>" />
+	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+<?php
+	/**
+	 * The template for displaying the header
+	 *
+	 * Contains the HEAD content and opening of the id=page and id=main DIV elements.
+	 *
+	 * @package Largo
+	 * @since 0.1
+	 */
+	?>
+	<link rel="profile" href="http://gmpg.org/xfn/11" />
+	<link rel="pingback" href="<?php bloginfo( 'pingback_url' ); ?>" />
+<?php
+	if ( is_singular() && get_option( 'thread_comments' ) )
+		wp_enqueue_script( 'comment-reply' );
+
+	wp_head();
+?>
+</head>
+
+<body <?php body_class(); ?>>
+
+	<div id="top"></div>
+
+	<?php
+
+	/**
+	 * Fires at the top of the page, just after the id=top DIV element.
+	 *
+	 * @since 0.4
+	 */
+	do_action( 'largo_top' );
+
+	?>
+
+	<?php
+		if ( SHOW_GLOBAL_NAV === TRUE ) {
+
+			/**
+			 * Fires before the Largo global navigation content.
+			 *
+			 * @since 0.4
+			 */
+			do_action( 'largo_before_global_nav' );
+
+			get_template_part( 'partials/nav', 'global' );
+
+			/**
+			 * Fires after the Largo global navigation content.
+			 *
+			 * @since 0.4
+			 */
+			do_action( 'largo_after_global_nav' );
+
+		}
+	?>
+
+	<div id="page" class="hfeed clearfix">
+
+		<?php
+
+			get_template_part( 'partials/nav', 'sticky' );
+
+			if ( of_get_option( 'leaderboard_enabled' ) == TRUE ) {
+				get_template_part( 'partials/header-ad-zone' );
+			}
+
+			/**
+			 * Fires before the Largo header content.
+			 *
+			 * @since 0.4
+			 */
+			do_action( 'largo_before_header' );
+
+			get_template_part( 'partials/largo-header' );
+
+			/**
+			 * Fires after the Largo header content.
+			 *
+			 * @since 0.4
+			 */
+			do_action( 'largo_after_header' );
+
+			get_template_part( 'partials/nav', 'main' );
+
+			if ( SHOW_SECONDARY_NAV === TRUE ) {
+				get_template_part( 'partials/nav', 'secondary' );
+			}
+
+			get_template_part('partials/homepage-alert');
+
+			/**
+			 * Fires after the Largo navigation content.
+			 *
+			 * @since 0.4
+			*/
+			do_action( 'largo_after_nav' );
+
+		?>
+
+		<div id="main" class="row-fluid clearfix">
+
+		<?php
+
+		/**
+		 * Fires at the top of the Largo id=main DIV element.
+		 *
+		 * @since 0.4
+		 */
+		do_action( 'largo_main_top' );


### PR DESCRIPTION
This solves the issue of duplicate title tags by adding in header.php from Largo and then removing the title tags from Largo. This is per INN/largo#1470 (comment): and follows the same steps taken here: https://github.com/INN/umbrella-rivard-report/pull/14/files