### PR TITLE
If Yoast's wordpress-seo plugin is active, don't run Largo's largo_opengraph function

### DIFF
--- a/wp-content/themes/mstoday/functions.php
+++ b/wp-content/themes/mstoday/functions.php
@@ -7,6 +7,7 @@ $includes = array(
 	'/homepages/homepage.php',
 	'/inc/DDCPC.php',
 	'/inc/post-tags.php',
+	'/inc/open-graph.php',
 );
 // Perform load
 foreach ( $includes as $include ) {

--- a/wp-content/themes/mstoday/inc/open-graph.php
+++ b/wp-content/themes/mstoday/inc/open-graph.php
@@ -7,6 +7,7 @@
  * Zero out the OpenGraph tags produced by Largo if Yoast is active
  *
  * @link https://github.com/INN/largo/issues/1437
+ * @link https://wordpress.org/plugins/wordpress-seo/
  * @since Largo 0.5.5.4
  * @since Yoast/wordpress-seo 7.6.1
  * @since WordPress 4.9.6

--- a/wp-content/themes/mstoday/inc/open-graph.php
+++ b/wp-content/themes/mstoday/inc/open-graph.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Replacements of Largo/inc/open-graph.php functions
+ */
+
+/**
+ * Zero out the OpenGraph tags produced by Largo if Yoast is active
+ *
+ * @link https://github.com/INN/largo/issues/1437
+ * @since Largo 0.5.5.4
+ * @since Yoast/wordpress-seo 7.6.1
+ * @since WordPress 4.9.6
+ */
+function mstoday_opengraph() {
+	// this is defined in wordpress-seo/wp-seo-main.php.
+	if ( ! defined( 'WPSEO_VERSION' ) ) {
+		largo_opengraph();
+	}
+}
+
+/**
+ * Dequeue largo_opengraph after it gets enqueued
+ */
+function mstoday_dequeue_largo_opengraph() {
+	remove_action( 'wp_head', 'largo_opengraph', 10 );
+	add_action( 'wp_head', 'mstoday_opengraph', 10 );
+}
+add_action( 'wp_head', 'mstoday_dequeue_largo_opengraph', 1 );


### PR DESCRIPTION
## Changes

- adds `inc/open-graph.php` to copy Largo's file
- dequeues largo's `largo_opengraph` from `wp_head`
- enqueues a function on `wp_head` that, if a constant defined in [Yoast's WordPress SEO plugin](https://wordpress.org/plugins/wordpress-seo/) is **not** defined, runs `largo_opengraph` on the assumption that the Yoast plugin is not active.

## Sources of tech debt

- this only works for Yoast
- this does not take any other open-graph-tag-emitting plugins into effect

## Why

Because Yoast was outputting `og:` tags that duplicated Largo's, and MS Today wants to use Yoast.

This will be copied into GIJN as well.