### PR TITLE
Removed getting byline from code for blank content template

### DIFF
--- a/wp-content/themes/mstoday/partials/content-blank.php
+++ b/wp-content/themes/mstoday/partials/content-blank.php
@@ -8,12 +8,6 @@
 
 	<?php do_action('largo_before_post_header'); ?>
 
-	<header>
-
-		<h5 class="byline"><?php largo_byline( true, false, get_the_ID() ); ?></h5>
-
-	</header>
-
 	<?php largo_post_metadata( $post->ID ); ?>
 
 	<?php


### PR DESCRIPTION
Having it in the template didn't work as expected since the client wanted the byline under the featured image, but the featured image is being inserted into a Gutenberg block. There's not a great way to insert the byline in the middle of `the_content` after the featured image, so maybe hardcoding it in the post is the best option.