### PR TITLE
3904 child theme updates

### DIFF
--- a/wp-content/themes/mstoday/functions.php
+++ b/wp-content/themes/mstoday/functions.php
@@ -9,6 +9,7 @@ $includes = array(
 	'/inc/post-tags.php',
 	'/inc/open-graph.php',
 	'/inc/blank-page-template.php',
+	'/inc/load-more-posts.php',
 );
 // Perform load
 foreach ( $includes as $include ) {
@@ -122,6 +123,7 @@ function mstoday_largo_shortcut_icons() {
 	add_action( 'wp_head', 'mstoday_shortcut_icons', 10 );
 }
 add_action( 'wp_head', 'mstoday_largo_shortcut_icons', 9 );
+
 /**
  * Add new specific touch icons
  */

--- a/wp-content/themes/mstoday/homepages/zones/mstoday-zones.php
+++ b/wp-content/themes/mstoday/homepages/zones/mstoday-zones.php
@@ -135,14 +135,7 @@ function zone_homepage_river() {
 		'posts_per_page' => 10,
 		'post__not_in' => $shown_ids,
 		'ignore_sticky_posts' => true,
-		'tax_query' => array(
-			array(
-				'taxonomy' => 'prominence',
-				'field'    => 'slug',
-				'terms'    => 'homepage-exclude',
-				'operator' => 'NOT IN',
-			),
-		),
+		'tax_query' => mstoday_homepage_tax_query(),
 	);
 	
 	if (of_get_option('num_posts_home'))

--- a/wp-content/themes/mstoday/inc/load-more-posts.php
+++ b/wp-content/themes/mstoday/inc/load-more-posts.php
@@ -22,3 +22,28 @@ function mstoday_homepage_tax_query() {
 		),
 	);
 }
+
+/**
+ * filter LMP query on homepage by changing the config that is output for the LMP button
+ *
+ * This is the easiest way to affect what is loaded by the LMP button on the homepage.
+ * The other option would be filtering largo_lmp_args, on the WP_Query that LMP runs, but that lacks
+ * context that we have here.
+ *
+ * @uses mstoday_homepage_tax_query
+ * @param Array $config the LMP config
+ * @return Array the modified config
+ * @since Largo 0.5.5.3
+ * @since July 2019
+ * @filter largo_load_more_posts_json
+ * @see largo_load_more_posts_data
+ * @see partials/home-post-list.php
+ * @link https://secure.helpscout.net/conversation/904103699/3904/?folderId=1219602
+ */
+function mstoday_homepage_largo_load_more_posts_json( $config ) {
+	if ( is_home() ) {
+		$config['query']['tax_query'] = mstoday_homepage_tax_query();
+	}
+	return $config;
+}
+add_filter( 'largo_load_more_posts_json', 'mstoday_homepage_largo_load_more_posts_json' );

--- a/wp-content/themes/mstoday/inc/load-more-posts.php
+++ b/wp-content/themes/mstoday/inc/load-more-posts.php
@@ -7,7 +7,7 @@
  */
 
 /**
- * Generate the tax_query args for thoe homepage fiver LMP
+ * Generate the tax_query args for the homepage river LMP
  *
  * @return Array
  * @link https://github.com/INN/umbrella-voiceofoc/blob/b90f7fa9b80cabc1f914140bb314a06f5d51836e/wp-content/themes/voiceofoc/inc/homepage.php#L24-L57

--- a/wp-content/themes/mstoday/inc/load-more-posts.php
+++ b/wp-content/themes/mstoday/inc/load-more-posts.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Functions modifying the mstoday child theme's Load More Posts behavior.
+ * 
+ * @link https://github.com/INN/umbrella-voiceofoc/blob/b90f7fa9b80cabc1f914140bb314a06f5d51836e/wp-content/themes/voiceofoc/inc/homepage.php a reference for this implementation
+ * @link https://secure.helpscout.net/conversation/904103699/3904/?folderId=1219602 an issue we had with it
+ */
+
+/**
+ * Generate the tax_query args for thoe homepage fiver LMP
+ *
+ * @return Array
+ * @link https://github.com/INN/umbrella-voiceofoc/blob/b90f7fa9b80cabc1f914140bb314a06f5d51836e/wp-content/themes/voiceofoc/inc/homepage.php#L24-L57
+ */
+function mstoday_homepage_tax_query() {
+	return array(
+		array(
+			'taxonomy' => 'prominence',
+			'field' => 'slug',
+			'terms' => 'homepage-exclude',
+			'operator' => 'NOT IN',
+		),
+	);
+}

--- a/wp-content/themes/mstoday/js/navigation.js
+++ b/wp-content/themes/mstoday/js/navigation.js
@@ -3,7 +3,6 @@
 
   var Navigation = function() {
     this.scrollTop = $(window).scrollTop();
-    this.previousScroll = null;
     this.initialLoad = true;
     return this.init();
   };
@@ -11,14 +10,22 @@
   /*
    * This is a shim to cover for the case where a browser may or may not have scrollbars
    * @link https://github.com/jquery/jquery/issues/1729
+   * @link https://github.com/INN/largo/pull/1369
+   *
+   * In some browsers, having the Inspector Tools docked within the browser in a sidebar
+   * configuration may cause abnormal readings for this value.
    */
   Navigation.prototype.windowwidth = function() {
-    return Math.max(window.outerWidth, $(window).width());
+    return Math.max(window.innerWidth, $(window).width());
   }
 
+  /**
+   * Set up the Navigation object
+   */
   Navigation.prototype.init = function() {
     // Dropdowns on touch screens
     this.enableMobileDropdowns();
+    this.toggleTouchClass();
 
     // Stick navigation
     this.stickyNavEl = $('.sticky-nav-holder');
@@ -26,7 +33,10 @@
     this.mainEl = $('#main');
     this.mainNavEl = $('#main-nav');
 
-    if ( this.windowwidth() > 768) {
+    // the currently-open menu Element (not a jQuery object);
+    this.openMenu = false;
+
+    if (this.windowwidth() > 768) {
       this.stickyNavTransition();
     }
 
@@ -36,39 +46,103 @@
     // Deal with long/wrapping navs
     setTimeout(this.navOverflow.bind(this), 0);
 
-    // Sticky nav on small viewports
+    // Nav on small viewports
     this.responsiveNavigation();
-    this.stickyNavEl.addClass('show');
+	this.stickyNavEl.addClass('show');
+
+    // Nav on touch devices on large viewports
+    this.touchDropdowns();
 
     return this;
   };
 
-  Navigation.prototype.enableMobileDropdowns = function () {
-    // Touch enable the drop-down menus
-    if (Modernizr.touch) {
-      // iOS Safari works with touchstart, the rest work with click
-      var mobileEvent = /Mobile\/.+Safari/.test(navigator.userAgent) ? 'touchstart' : 'click',
-      // Open the drop down
-      openMenu = false;
+  /**
+   * Run the Modernizr.touch and Modernizr.pointerevents tests at will
+   *
+   * because Modernizr doesn't allow rerunning the tests, so the availablilty of an input device changes while the page is loaded, the Modernizr.touch property will be inaccurate
+   *
+   * @link https://github.com/Modernizr/Modernizr/blob/e2c27dcd32d6185846ce3c6c83d7634cfa402d19/feature-detects/touchevents.js
+   * @link https://github.com/Modernizr/Modernizr/blob/e2c27dcd32d6185846ce3c6c83d7634cfa402d19/feature-detects/pointerevents.js
+   * @return bool whether or not this is (probably) a touch device at this time
+   */
+  Navigation.prototype.touch = function () {
+    if (('ontouchstart' in window) || window.DocumentTouch && document instanceof DocumentTouch) {
+      return true;
+    }
 
-      // Call this to close the open menu
-      var closeOpenMenu = function() {
-        if (openMenu) {
-          openMenu.removeClass('open');
-          openMenu = false;
-        }
+    domPrefixes = Modernizr._domPrefixes;
+    var bool = false,
+           i = domPrefixes.length;
+
+    // Don't forget un-prefixed...
+    bool = Modernizr.hasEvent('pointerdown');
+
+    while (i-- && !bool) {
+      if (Modernizr.hasEvent(domPrefixes[i] + 'pointerdown')) {
+        bool = true;
+      }
+    }
+    return bool;
+  }
+
+  /**
+   * If a nav dropdown element is open, and something outside is clicked, close the menu
+   */
+  Navigation.prototype.enableMobileDropdowns = function () {
+    var self = this;
+
+    // Call this to close the open menu
+    var closeOpenMenu = function(event) {
+      // If it is a touch event, get rid of the click events.
+      if (event.type == 'touchstart') {
+        $(this).off('click.touchDropdown');
       }
 
-      // Close the open menu when the user taps elsewhere
-      $('body').on(mobileEvent, closeOpenMenu);
+      if (self.openMenu) {
+        if (self.openMenu.parentElement.contains( event.target ) ) {
+          // gotta navigate.
+          window.location = event.target.href;
+          // for top-level items, the link is handled natively.
+          // items in the dropdown, it isn't.
+        }
+
+        self.openMenu.parentNode.classList.remove('open');
+        self.openMenu = false;
+        // we can't event.preventDefault here because of Chrome/Opera:
+        // https://www.chromestatus.com/feature/5093566007214080
+      }
     }
+
+    // Close the open menu when the user taps elsewhere
+    // Should this be scoped to not be on document/html/body?
+    // No; because div.global-nav-bg #page and div.footer-bg are separate things,
+    // and together they do not cover all of body.
+    $('body').on('touchstart.touchDropdown click.touchDropdown' , closeOpenMenu);
   };
+
+  /**
+   * Toggle the Modernizr-added .touch and .no-touch classes
+   */
+  Navigation.prototype.toggleTouchClass = function () {
+    $html = $('html');
+    if (this.touch()) {
+      $html.addClass('touch').removeClass('no-touch');
+    } else {
+      $html.addClass('no-touch').removeClass('touch');
+    }
+  }
 
   Navigation.prototype.bindEvents = function() {
     $(window).resize(this.navOverflow.bind(this));
+    $(window).resize(this.enableMobileDropdowns.bind(this));
+    $(window).resize(this.toggleTouchClass.bind(this));
+    $(window).resize(this.touchDropdowns.bind(this));
     this.bindStickyNavEvents();
   };
 
+  /**
+   * Attach sticky nav resize event handlers to their events
+   */
   Navigation.prototype.bindStickyNavEvents = function() {
     var self = this;
 
@@ -79,36 +153,158 @@
         self.stickyNavEl.addClass(idx);
     });
 
-    $(window).on('resize', this.stickyNavResizeCallback.bind(this));
+    $(window).on('scroll resize', this.stickyNavScrollCallback.bind(this));
 
     this.stickyNavResizeCallback();
-    this.stickyNavSetOffset();
   };
 
   Navigation.prototype.stickyNavResizeCallback = function() {
-    this.stickyNavSetOffset();
+    if (
+      this.windowwidth() <= 768
+      || (
+        Largo.sticky_nav_options.main_nav_hide_article
+        && (
+          $('body').hasClass('single')
+          || $('body').hasClass('page')
+        )
+      )
+    ) {
+      this.stickyNavEl.addClass('show');
+      this.stickyNavEl.parent().css('height', this.stickyNavEl.outerHeight());
+    } else if (
+      Largo.sticky_nav_options.sticky_nav_display
+    ) {
+      this.stickyNavEl.parent().css('height', '');
+    } else {
+      this.stickyNavEl.parent().css('height', '');
+    }
     this.stickyNavTransitionDone();
   };
 
-  Navigation.prototype.stickyNavSetOffset = function() {
-    if ($('body').hasClass('admin-bar')) {
-      if ($(window).scrollTop() <= $('#wpadminbar').outerHeight()) {
-        this.stickyNavEl.css('top', $('#wpadminbar').outerHeight());
-      } else {
-        this.stickyNavEl.css('top', '');
+
+  /**
+   * Determine whether or not to show or hide the sticky nav in response to scrolling
+   */
+  Navigation.prototype.stickyNavScrollCallback = function(event) {
+    if (
+      $(window).scrollTop() < 0
+      || ( $(window).scrollTop() + $(window).outerHeight() ) >= $(document).outerHeight()
+    ) {
+      // if we're scrolled past the top of the page
+      // or if the window is taller than the document
+      // then it doesn't make sense to do the logic in this function.
+      return;
+    }
+
+    if (
+      this.windowwidth() > 768
+      && !Largo.sticky_nav_options.sticky_nav_display
+    ) {
+      // if we're in a non-mobile case and the sticky nav is set to not display
+      // then we should not be changing the status of the sticky nav based on height.
+      return;
+    }
+
+    var self = this,
+        callback, wait;
+
+    // this.mainEl (#main) exists in all Largo templates.
+    if ( $(window).scrollTop() <= this.mainEl.offset().top ) {
+      // we're near the top of the page, so now let's consider whether to hide the sticky nav:
+      // if main_nav_hide_article is true, mainNavEl won't exist.
+      if ( this.mainNavEl.length && this.mainNavEl.is(':visible') ) {
+        // the main nav exists and is visible,
+        // so we should hide the sticky nav
+        this.stickyNavEl.removeClass('show');
+        clearTimeout(this.scrollTimeout);
+        return; // don't need to do the other logic; it shouldn't show anyways
       }
     }
+
+    clearTimeout(this.scrollTimeout);
+
+    this.scrollTimeout = setTimeout(callback, wait);
   };
 
+  /**
+   * Touch/click event handler for sticky nav and main nav items
+   *
+   * Goals:
+   * - open when tapped, event.preventDefault
+   * - when open, click on link follows that link
+   *
+   * Largo does not support a three-level menu, so no need to worry about dropdowns off the dropdown.
+   *
+   * @todo: prevent this from triggering on the mobile nav
+   */
+  Navigation.prototype.touchDropdowns = function() {
+
+    /*
+     * Define some event handlers
+     */
+
+    // Open the drawer when touched or clicked
+    function touchstart(event) {
+      // prevents this from running when the sandwich menu button is visible:
+      // prevents this from running when we're doing the "phone" menu
+      if ($('.navbar .toggle-nav-bar').css('display') !== 'none') {
+        return false;
+      }
+
+      if ($(this).closest('.dropdown').hasClass('open')) {
+      } else {
+        // If it is a touch event, get rid of the click events.
+        if (event.type == 'touchstart') {
+          $(this).off('click.toggleNav');
+        }
+        $(this).parent('.dropdown').addClass('open');
+        $(this).parent('.dropdown').addClass('open');
+        self.openMenu = this;
+        event.preventDefault();
+        event.stopPropagation();
+      }
+    }
+
+    // if the touch is canceled, close the nav
+    function touchcancel(event) {
+      $(this).parent('.dropdown').removeClass('open');
+    }
+
+    /*
+     * Attach or detach them as appropriate
+     */
+
+    var self = this;
+
+    // a selector that applies to both main-nav and sticky nav elements
+    $('.nav li > .dropdown-toggle').each(function() {
+      var $button = $(this);
+
+      if(self.windowwidth() > 768 ){
+        $button.on('touchstart.toggleNav click.toggleNav', touchstart);
+        $button.on('touchcancel.toggleNav', touchcancel);
+        $button.off('touchstart.toggleNav click.toggleNav');
+        $button.off('touchcancel.toggleNav');
+      }
+    });
+
+  }
+
+  /**
+   * Touch menu interactions and menu appearance on "phone" screen sizes.
+   */
   Navigation.prototype.responsiveNavigation = function() {
     var self = this;
 
-    // Responsive navigation
+    // Tap/click this button to open/close the phone navigation, which shows on narrower viewports
     $('.navbar .toggle-nav-bar').each(function() {
+      // the hamburger
       var toggleButton = $(this),
-          navbar = toggleButton.closest('.navbar');
+        // the parent nav of the hamburger
+        navbar = toggleButton.closest('.navbar');
 
       // Support both touch and click events
+      // The .toggleNav here is namespacing the click event: https://api.jquery.com/on/#event-names
       toggleButton.on('touchstart.toggleNav click.toggleNav', function(event) {
         // If it is a touch event, get rid of the click events.
         if (event.type == 'touchstart') {
@@ -117,7 +313,6 @@
 
         navbar.toggleClass('open');
         $('html').addClass('nav-open');
-        self.stickyNavSetOffset();
         navbar.find('.nav-shelf').css({
           top: self.stickyNavEl.position().top + self.stickyNavEl.outerHeight()
         });
@@ -130,16 +325,19 @@
         return false;
       });
 
-      // Secondary nav
+      // Secondary nav items in the drop-down
       navbar.on('touchstart.toggleNav click.toggleNav', '.nav-shelf .caret', function(event) {
-        if (toggleButton.css('display') == 'none')
+        // prevents this from running when the sandwich menu button is not visible:
+        // prevents this from running when we're not doing the "phone" menu
+        if (toggleButton.css('display') == 'none') {
           return false;
+        }
 
         if (event.type == 'touchstart') {
           navbar.off('click.toggleNav', '.nav-shelf .dropdown-toggle');
         }
 
-        var li = $( event.target ).closest('li');
+        var li = $(event.target).closest('li');
 
         if (!li.hasClass('open')) {
           navbar.find('.nav-shelf li.open').removeClass('open');
@@ -178,7 +376,6 @@
         shelfWidth = shelf.outerWidth(),
         rightWidth = right.outerWidth(),
         caretWidth = nav.find('.caret').first().outerWidth(),
-        windowWidth = this.windowwidth(),
         isMobile = button.is(':visible');
 
     if (!isMobile) {
@@ -190,7 +387,7 @@
        * Calculate the width of the nav
        */
       var navWidth = 0;
-      shelf.find('ul.nav > li').each( function() {
+      shelf.find('ul.nav > li').each(function() {
         if ($(this).is(':visible'))
           navWidth += $(this).outerWidth();
       });
@@ -241,7 +438,7 @@
        * If the nav is still wrapping, call navOverflow again.
        */
       var navWidth = 0;
-      shelf.find('ul.nav > li').each( function() {
+      shelf.find('ul.nav > li').each(function() {
         if ($(this).is(':visible'))
           navWidth += $(this).outerWidth();
       });
@@ -286,7 +483,7 @@
       shelf.find('ul.nav > li.menu-item').last().after(li);
     });
 
-    if (overflow.find('ul li').length == 0 ) {
+    if (overflow.find('ul li').length == 0) {
       overflow.remove();
     }
   };
@@ -294,8 +491,11 @@
   if (typeof window.Navigation == 'undefined')
     window.Navigation = Navigation;
 
+  /**
+   * Initialize the Navigation
+   */
   $(document).ready(function() {
-    new Navigation();
+    // make this Navigation available to inspectors.
+    window.Largo.navigation = new Navigation();
   });
-
 })();

--- a/wp-content/themes/mstoday/js/readme.md
+++ b/wp-content/themes/mstoday/js/readme.md
@@ -1,0 +1,7 @@
+## navigation.js
+
+`mstoday/js/navigation.js` is a clone of the current Largo navigation.js, with the code related to showing/hiding the nav on scroll removed. This is so that the sticky nav on the "blank page" template remains always visible.
+
+To update that file, copy largo's `navigation.js` into this folder, then remove all the `direction`-related code.
+
+The file is only enqueued on the `single-blank.php` template, and is enqueued by the function `mstoday_blank_page_largo_nav_js` in `inc/blank-page-template.php`.

--- a/wp-content/themes/mstoday/readme.md
+++ b/wp-content/themes/mstoday/readme.md
@@ -4,7 +4,7 @@
 
 - `single-blank.php` is an extension of the Largo single-column single-post template that removes the standard top-of-post header of top tag, headline, byline, post featured media, and post social buttons. This template enqueues a number of functions in `inc/blank-page-template.php`, which affect the following things:
 	- edits the `of_get_option` return to disable the post floating social buttons and main nav
-	- replaces Largo's navigation.js with `js/navigation.js` to always remain visible at the top of the page
+	- replaces Largo's navigation.js with `js/navigation.js` to always remain visible at the top of the page, see `js/readme.md`
 - Has a custom homepage
 - `inc/open-graph.php` is outdated by Largo 0.6, and should be removed at some point in the future
 - uses INN's Developer-Driven Custom Post Classes plugin for some post classes.


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Updates Largo to 0.6.4
- Updates the blank page's `js/navigation.js` for Largo 0.6.4 compat and adds instructions on how to do so.
- Fixes issue where args used to exclude posts from the homepage bottom were not being applied to the LMP query for that homepage bottom area
- 

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For Helpscout 3904

## Testing/Questions

Features that this PR affects:

- blank page template
- Homepage LMP

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [x] okay with client?

Steps to test this PR:

1. <!-- list any configuration changes, settings, test content, or other things necessary to test this change. -->