### PR TITLE
Fix photo captions and dropcap on apple news

### DIFF
--- a/wp-content/themes/mstoday/functions.php
+++ b/wp-content/themes/mstoday/functions.php
@@ -156,3 +156,106 @@ function mstoday_add_wide_image_support() {
   add_theme_support( 'align-wide' );
 }
 add_action( 'after_setup_theme', 'mstoday_add_wide_image_support' );
+
+/**
+ * A shim to make captions in articles show as actual captions instead of as body content.
+ * 
+ * Waiting for this to be fixed in the actual ANP plugin. 
+ * https://github.com/INN/umbrella-mstoday/issues/57#issuecomment-580844062
+ * 
+ * The general idea here is to find all images attached to the post, find their
+ * captions and media credits, then loop through $json and if any body component matches
+ * an image caption/credit, change that component to be `role = caption` instead of `role = body`.
+ * 
+ * @param arr $json An array of the post content in JSON format
+ * @param int $post_id The post id
+ * 
+ * @return arr @json The modified post content JSON
+ */
+function mstoday_apple_news_article_update_captions_shim( $json, $post_id ){
+
+	// grab all attachments tied to this post
+	$attachments = get_attached_media( 'image', $post->ID );
+
+	// init empty arr
+	$captions_and_credits = array();
+
+	// loop through all returned attachments and add their captions and 
+	// credits to our $captions_and_credits arr
+	foreach( $attachments as $attachment ){
+
+		$attachment_caption = wp_get_attachment_caption( $attachment->ID );
+		$attachment_credit = navis_get_media_credit( $attachment->ID );
+
+		if( !empty( $attachment_caption ) ) {
+			array_push( $captions_and_credits, preg_replace("/[^a-z0-9.]+/i", "", $attachment_caption ) );
+		}
+
+		if( !empty( $attachment_credit->credit ) ) {
+			array_push( $captions_and_credits, preg_replace("/[^a-z0-9.]+/i", "", $attachment_credit->credit ) );
+		}
+
+		if( !empty( $attachment_credit->org ) ) {
+			array_push( $captions_and_credits, preg_replace("/[^a-z0-9.]+/i", "", $attachment_credit->org ) );
+		}
+
+	}
+
+	// woohoo set an index
+	$index = -1;
+	$dropcap_set = false;
+
+	// this is where the fun begins
+	// loop through all $json body components and if one matches a caption/credit, update its role
+	foreach( $json['components'] as $component ) {
+
+		$index++;
+
+		// we have to make it only alphanumeric because this plugin is annoying and adds way too much whitespace
+		// that doesn't want to be stripped out with trim, str_replace, etc.
+		$component_text = preg_replace("/[^a-z0-9.]+/i", "", $component['text']);
+		$component_text = trim( $component_text, 'p' );
+	
+		// if the component text actually matches a credit or caption, update it
+		if( in_array( $component_text, $captions_and_credits ) ) {
+			
+			// that's better (hopefully)
+			$json['components'][$index]['role'] = 'caption';
+			$json['components'][$index]['textStyle'] = array(
+				"textAlignment" => "left",
+				"fontName" => "Helvetica-Bold",
+				"fontSize" => 14,
+			);
+
+			// who needs a layout if you're a caption
+			unset($json['components'][$index]['layout']);
+
+		}
+
+		// if a dropcap component is found, make sure we don't update any others to use a dropcap
+		if( false === $dropcap_set && 'dropcapBodyStyle' === $json['components'][$index]['textStyle'] ) {
+
+			$dropcap_set = true;
+
+		}
+
+		// terrible way to fix the dropcap, but it's the only way that works
+		// if this component has role = body and the dropcap has not yet been set, 
+		// we can go ahead and safely add the dropcap to this component
+		if( false === $dropcap_set && 'body' === $json['components'][$index]['role'] ) {
+			
+			$json['components'][$index]['textStyle'] = 'dropcapBodyStyle';
+			$dropcap_set = true;
+
+		}
+
+	}
+
+	// uncomment if you're interested in seeing what the $json looks like
+	// print("<pre>".print_r($json,true)."</pre>");
+	// die();
+
+	return $json;
+
+}
+add_filter('apple_news_generate_json', 'mstoday_apple_news_article_update_captions_shim', 10, 2);

--- a/wp-content/themes/mstoday/functions.php
+++ b/wp-content/themes/mstoday/functions.php
@@ -185,18 +185,23 @@ function mstoday_apple_news_article_update_captions_shim( $json, $post_id ){
 	foreach( $attachments as $attachment ){
 
 		$attachment_caption = wp_get_attachment_caption( $attachment->ID );
-		$attachment_credit = navis_get_media_credit( $attachment->ID );
+
+		if ( function_exists( 'navis_get_media_credit' ) ) {
+			$attachment_credit = navis_get_media_credit( $attachment->ID );
+		}
 
 		if( !empty( $attachment_caption ) ) {
 			array_push( $captions_and_credits, preg_replace("/[^a-z0-9.]+/i", "", $attachment_caption ) );
 		}
 
-		if( !empty( $attachment_credit->credit ) ) {
-			array_push( $captions_and_credits, preg_replace("/[^a-z0-9.]+/i", "", $attachment_credit->credit ) );
-		}
+		if( isset( $attachment_credit ) && !empty( $attachment_credit ) ) {
+			if( !empty( $attachment_credit->credit ) ) {
+				array_push( $captions_and_credits, preg_replace("/[^a-z0-9.]+/i", "", $attachment_credit->credit ) );
+			}
 
-		if( !empty( $attachment_credit->org ) ) {
-			array_push( $captions_and_credits, preg_replace("/[^a-z0-9.]+/i", "", $attachment_credit->org ) );
+			if( !empty( $attachment_credit->org ) ) {
+				array_push( $captions_and_credits, preg_replace("/[^a-z0-9.]+/i", "", $attachment_credit->org ) );
+			}
 		}
 
 	}


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

(I'm sorry, @benlk)
- Adds a new shim function (`mstoday_apple_news_article_update_captions_shim`) that fires on the `apple_news_generate_json` filter to find photo captions in the apple news generated JSON and give them the correct component role (`caption` instead of `body`), and also (hopefully) fix the dropcap being assigned to the wrong component

Some examples of this working:
![Screen Shot 2020-01-31 at 5 04 44 PM](https://user-images.githubusercontent.com/18353636/73577816-f2810880-444b-11ea-89fe-5e22ffe661e9.png)
![Screen Shot 2020-01-31 at 5 04 50 PM](https://user-images.githubusercontent.com/18353636/73577815-f2810880-444b-11ea-936d-f66b667b0000.png)

Also, good to note that this is just a temporary shim until the plugin is updated:
Related issue in the AN plugin repo: alleyinteractive/apple-news#692

Looks like a fix has been added alleyinteractive/apple-news#700 but has not been released yet.

Also good to note that this wasn't working on my local environment due to lack of images. I put the code on their staging environment and was downloading articles from there.

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For #57

## Testing/Questions

Features that this PR affects:

- Apple News articles

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [ ] Is this PR targeting the correct branch in this repository?
- [ ] I realize this is a terrible, horrible, no good way to do this... but it was the only way that worked. Could anything be improved upon?

Steps to test this PR:

1. Open Apple News Preview
2. Open this test article with it and preview it and make sure nothing looks horrible
[HeadlineAboveImage.zip](https://github.com/INN/umbrella-mstoday/files/4141571/HeadlineAboveImage.zip)
3. You can try this with other articles, but note that you'll need to:
   - download the .json file and replace `article.json` in the above zip with it
   - download all images from said article and add them to the sample folder from the above zip