### PR TITLE
MS Today Woocommerce updates

### DIFF
--- a/wp-content/themes/mstoday/full-page.php
+++ b/wp-content/themes/mstoday/full-page.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Template Name: Full Width Page
+ * Single Post Template: Full-width (no sidebar)
+ * Description: Shows the post but does not load any sidebars, allowing content to span full container width.
+ *
+ * @package Largo
+ * @since 0.1
+ */
+get_header();
+?>
+
+<div id="content" class="span12" role="main">
+	<?php
+		while ( have_posts() ) : the_post();
+
+			$shown_ids[] = get_the_ID();
+
+			$partial = ( is_page() ) ? 'page' : 'single';
+
+			get_template_part( 'partials/content', $partial );
+
+			if ( $partial === 'single' ) {
+				comments_template( '', true );
+			}
+
+		endwhile;
+	?>
+</div>
+
+<?php get_footer();

--- a/wp-content/themes/mstoday/full-page.php
+++ b/wp-content/themes/mstoday/full-page.php
@@ -14,8 +14,6 @@ get_header();
 	<?php
 		while ( have_posts() ) : the_post();
 
-			$shown_ids[] = get_the_ID();
-
 			$partial = ( is_page() ) ? 'page' : 'single';
 
 			get_template_part( 'partials/content', $partial );

--- a/wp-content/themes/mstoday/functions.php
+++ b/wp-content/themes/mstoday/functions.php
@@ -156,3 +156,64 @@ function mstoday_add_wide_image_support() {
   add_theme_support( 'align-wide' );
 }
 add_action( 'after_setup_theme', 'mstoday_add_wide_image_support' );
+
+/**
+ * Copied from largo_layout_meta_box_dsiplay()
+ * https://github.com/INN/largo/blob/512da701664b329f2f92244bbe54880a6e146431/inc/post-metaboxes.php#L169-L198
+ * 
+ * The only modification that's made here is it only fires if the post type is page
+ * and switches all `post` to `page` in titles/descriptions
+ */
+function mstoday_layout_meta_box_display () {
+	global $post;
+
+	wp_nonce_field( 'largo_meta_box_nonce', 'meta_box_nonce' );
+
+	$current_template = (of_get_option('single_template') == 'normal')? __('One Column (Standard)', 'largo'):__('Two Column (Classic)', 'largo');
+
+	if ( $post->post_type == 'page' ) {
+		echo '<p><strong>' . __('Template', 'largo' ) . '</strong></p>';
+		echo '<p>' . __('Select the page template you wish this page to use.', 'largo') . '</p>';
+		echo '<label class="hidden" for="post_template">' . __("Page Template", 'largo' ) . '</label>';
+		echo '<select name="_wp_post_template" id="post_template" class="dropdown">';
+		echo '<option value="">' . sprintf(__( 'Default: %s', 'largo' ), $current_template) . '</option>';
+		post_templates_dropdown(); //get the options
+		echo '</select>';
+	}
+
+	echo '<p><strong>' . __('Custom Sidebar', 'largo' ) . '</strong><br />';
+	echo __('Select a custom sidebar to display.', 'largo' ) . '</p>';
+	echo '<label class="hidden" for="custom_sidebar">' . __("Custom Sidebar", 'largo' ) . '</label>';
+	echo '<select name="custom_sidebar" id="custom_sidebar" class="dropdown">';
+	largo_custom_sidebars_dropdown(); //get the options
+	echo '</select>';
+}
+
+/**
+ * Actually adds the layout metabox to the page editor
+ */
+function mstoday_add_layout_meta_box_to_pages() {
+	largo_add_meta_box(
+		'mstoday_layout_meta',
+		__( 'Layout Options', 'mstoday' ),
+		'mstoday_layout_meta_box_display',
+		array('page'),
+		'side',
+		'core'
+	);
+}
+add_filter( 'init', 'mstoday_add_layout_meta_box_to_pages' );
+
+/**
+ * Expanding Largo get_post_template() to also fire on pages
+ * https://github.com/INN/largo/blob/512da701664b329f2f92244bbe54880a6e146431/inc/post-templates.php#L64-L84
+ * 
+ * Filters the page template value, and replaces it with
+ * the template chosen by the user, if they chose one.
+ */
+function mstoday_get_page_template() {
+	if( function_exists( 'get_post_template' ) ) {
+		add_filter( 'page_template', 'get_post_template' );
+	}
+}
+add_filter( 'init', 'mstoday_get_page_template' );

--- a/wp-content/themes/mstoday/partials/content-single-product.php
+++ b/wp-content/themes/mstoday/partials/content-single-product.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * The template for displaying content in the single.php template
+ * The template for displaying Woocommerce products in single-product.php
  */
 ?>
 

--- a/wp-content/themes/mstoday/partials/content-single-product.php
+++ b/wp-content/themes/mstoday/partials/content-single-product.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * The template for displaying content in the single.php template
+ */
+?>
+
+<article id="post-<?php the_ID(); ?>" <?php post_class( 'hnews item' ); ?> itemscope itemtype="https://schema.org/Article">
+
+	<?php do_action('largo_before_post_header'); ?>
+
+	<header>
+
+		<?php largo_maybe_top_term(); ?>
+
+		<h1 class="entry-title" itemprop="headline"><?php the_title(); ?></h1>
+		<?php if ( $subtitle = get_post_meta( $post->ID, 'subtitle', true ) ) : ?>
+			<h2 class="subtitle"><?php echo $subtitle ?></h2>
+		<?php endif; ?>
+
+<?php largo_post_metadata( $post->ID ); ?>
+
+	</header><!-- / entry header -->
+
+    <?php 
+    
+        if( function_exists( 'woocommerce_get_product_thumbnail' ) ) {
+            echo woocommerce_get_product_thumbnail( 'large' );
+        }
+    
+    ?>
+
+	<section class="entry-content clearfix" itemprop="articleBody">
+		
+		<?php largo_entry_content( $post ); ?>
+		
+	</section>
+
+</article>

--- a/wp-content/themes/mstoday/single-product.php
+++ b/wp-content/themes/mstoday/single-product.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Single Post Template: One Column (Standard Layout)
+ * Template Name: One Column (Standard Layout)
+ * Description: Shows the post with a small right sidebar 
+ */
+
+global $shown_ids;
+
+add_filter( 'body_class', function( $classes ) {
+	$classes[] = 'normal';
+	return $classes;
+} );
+
+get_header();
+?>
+
+<div id="content" role="main">
+	<?php
+		while ( have_posts() ) : the_post();
+
+            $partial = 'single-product';
+			get_template_part( 'partials/content', $partial );
+
+		endwhile;
+	?>
+</div>
+
+<?php get_footer();

--- a/wp-content/themes/mstoday/single-product.php
+++ b/wp-content/themes/mstoday/single-product.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * Single Post Template: One Column (Standard Layout)
- * Template Name: One Column (Standard Layout)
- * Description: Shows the post with a small right sidebar 
+ * Woocommerce Single Product
+ * Template Name: Woocommerce Single Product
+ * Description: Shows Woocommerce products without any article widgets
  */
 
 global $shown_ids;


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Copies over `largo_layout_meta_box_display` and modifies it to allow the template selector to show on pages as well
https://github.com/INN/largo/blob/512da701664b329f2f92244bbe54880a6e146431/inc/post-metaboxes.php#L169-L198
- Adds new `full-page.php` template that displays the content the same way but using different conditionals because WP didn't like the default Largo `full-page.php` way
```
			$partial = ( is_page() ) ? 'page' : 'single';
			get_template_part( 'partials/content', $partial );
			if ( $partial === 'single' ) {
				comments_template( '', true );
			}
```
instead of
```
			if ( is_page() ) {
				get_template_part( 'partials/content', 'page' );
			} else {
				get_template_part( 'partials/content', 'single' );
				comments_template( '', true );
			}
```
- Adds new template and partial for single woocommerce products:
   - shows woocom product image
   - no author bio or any other article bottom widgets
![Screen Shot 2020-02-04 at 9 48 17 AM](https://user-images.githubusercontent.com/18353636/73755242-bd1e3880-4733-11ea-9323-21ce6193c58b.png)

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For #59

## Testing/Questions

Features that this PR affects:

- Page templates
- Woocommerce product template

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [x] Is this PR targeting the correct branch in this repository?
- [x] Is `init` an ok filter to fire `mstoday_add_layout_meta_box_to_pages` and `mstoday_get_page_template` on?
- [ ] I didn't notice any issues with css that needed to be addressed while using post templates on pages. Do you see any?

Steps to test this PR:

1. Install and active woocommerce
2. Select a `shop` page at `woocommerce` -> `settings` -> `products` (i did this, but didn't ever actually see any products appear on that page. assuming i missed a step in the setup)
3. Edit a page and try out each template. View each one on the frontend and verify they all look and function ok
4. Add a product with a product image and view it on the frontend. Make sure that new template looks and functions ok.