### PR TITLE
Add a "Single Post Widget"

### DIFF
--- a/wp-content/themes/mstoday/functions.php
+++ b/wp-content/themes/mstoday/functions.php
@@ -10,6 +10,7 @@ $includes = array(
 	'/inc/open-graph.php',
 	'/inc/blank-page-template.php',
 	'/inc/load-more-posts.php',
+	'/inc/widget-single-post.php',
 );
 // Perform load
 foreach ( $includes as $include ) {
@@ -99,9 +100,9 @@ add_action( 'largo_loop_after_post_x', 'mstoday_interstitial', 10, 2 );
  * @uses remove_action (which in turn uses remove_filter, see https://developer.wordpress.org/reference/functions/remove_filter/)
  * @link https://github.com/INN/Largo/blob/master/inc/taxonomies.php#L346 see largo_category_archive_posts, which is what we're removing.
  */
-function mstoday_remove_category_header_on_this_one_specific_category() {
+function mstoday_remove_category_header_on_this_one_specific_category( $query ) {
 	$qo = get_queried_object();
-	if ( is_main_query() && is_category() &&
+	if ( $query->is_main_query() && $query->is_category() &&
 		( 'around-the-state' === $qo->slug || 'mississippi-roundup' === $qo->slug )
 	) {
 		remove_action( 'pre_get_posts', 'largo_category_archive_posts', 15 );

--- a/wp-content/themes/mstoday/inc/widget-single-post.php
+++ b/wp-content/themes/mstoday/inc/widget-single-post.php
@@ -21,12 +21,12 @@ class MStoday_Single_Post extends WP_Widget {
 	public function __construct() {
 
 		$widget_ops = array(
-			'classname' => 'mstoday-single-post',
+			'classname' => 'mstoday-single-post largo-recent-posts',
 			'description' => __( 'Displays a single post.', 'mstoday' ),
 		);
 		parent::__construct(
 			'mstoday-single-post', // Base ID
-			__( 'Mississippi Today Single Post', 'mstoday' ), // Name
+			__( 'MS Today Single Post', 'mstoday' ), // Name
 			$widget_ops // Args
 		);
 
@@ -57,7 +57,6 @@ class MStoday_Single_Post extends WP_Widget {
 		$thumb = isset( $instance['thumbnail_display'] ) ? $instance['thumbnail_display'] : 'small';
 		$excerpt = isset( $instance['excerpt_display'] ) ? $instance['excerpt_display'] : 'num_sentences';
 		$post_id = isset( $instance['post_id'] ) ? $instance['post_id'] : null;
-		error_log(var_export( $post_id, true));
 
 		$query_args = array (
 			'post_status'    => 'publish',
@@ -156,11 +155,7 @@ class MStoday_Single_Post extends WP_Widget {
 
 	public function form( $instance ) {
 		$defaults = array(
-			'title' => sprintf(
-				// translators: %s is the word this site uses for "posts", like "articles" or "stories". It's a plural noun.
-				__( 'Recent %1$s' , 'largo' ),
-				of_get_option( 'posts_term_plural', 'Posts' )
-			),
+			'title' => __( 'Single Post' , 'largo' ),
 			'post_id' => null,
 			'thumbnail_display' => 'small',
 			'image_align' => 'left',
@@ -184,18 +179,21 @@ class MStoday_Single_Post extends WP_Widget {
 
 		<p>
 			<label for="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>"><?php esc_html_e( 'Title:', 'largo' ); ?></label>
-			<input id="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'title' ) ); ?>" value="<?php echo esc_attr( $instance['title'] ); ?>" style="width:90%;" type="text" />
+			<input id="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'title' ) ); ?>" value="<?php echo esc_attr( $instance['title'] ); ?>" style="" class="widefat" type="text" />
 		</p>
 
 		<p>
 			<label for="<?php echo esc_attr( $this->get_field_id( 'post_id' ) ); ?>"><?php esc_html_e( 'ID of post to show:', 'mstoday' ); ?></label>
-			<input id="<?php echo esc_attr( $this->get_field_id( 'post_id' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'post_id' ) ); ?>" value="<?php echo esc_attr( $instance['post_id'] ); ?>" style="width:90%;" type="number" />
+			<input id="<?php echo esc_attr( $this->get_field_id( 'post_id' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'post_id' ) ); ?>" value="<?php echo esc_attr( $instance['post_id'] ); ?>" style="clear: both;" class="widefat" type="number" />
+			<label for="<?php echo esc_attr( $this->get_field_id( 'post_id' ) ); ?>">
+				<?php echo wp_kses_post( __( 'The post ID is the <code>130248</code> in the <code>/wp-admin/post.php?post=130248&action=edit</code> part of the URL when you edit a post.', 'mstoday' ) ); ?>
+			</label>
 		</p>
 
 
 		<p>
 			<label for="<?php echo esc_attr( $this->get_field_id( 'thumbnail_display' ) ); ?>"><?php esc_html_e( 'Thumbnail Image', 'largo' ); ?></label>
-			<select id="<?php echo esc_attr( $this->get_field_id( 'thumbnail_display' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'thumbnail_display' ) ); ?>" class="widefat" style="width:90%;">
+			<select id="<?php echo esc_attr( $this->get_field_id( 'thumbnail_display' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'thumbnail_display' ) ); ?>" class="widefat" style="">
 				<option <?php selected( $instance['thumbnail_display'], 'small' ); ?> value="small"><?php esc_html_e( 'Small (60x60)', 'largo' ); ?></option>
 				<option <?php selected( $instance['thumbnail_display'], 'medium' ); ?> value="medium"><?php esc_html_e( 'Medium (140x140)', 'largo' ); ?></option>
 				<option <?php selected( $instance['thumbnail_display'], 'large' ); ?> value="large"><?php esc_html_e( 'Large (Full width of the widget)', 'largo' ); ?></option>
@@ -206,7 +204,7 @@ class MStoday_Single_Post extends WP_Widget {
 		<!-- Image alignment -->
 		<p>
 			<label for="<?php echo esc_attr( $this->get_field_id( 'image_align' ) ); ?>"><?php esc_html_e( 'Image Alignment', 'largo' ); ?></label>
-			<select id="<?php echo esc_attr( $this->get_field_id( 'image_align' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'image_align' ) ); ?>" class="widefat" style="width:90%;">
+			<select id="<?php echo esc_attr( $this->get_field_id( 'image_align' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'image_align' ) ); ?>" class="widefat" style="">
 				<option <?php selected( $instance['image_align'], 'left' ); ?> value="left"><?php esc_html_e( 'Left align', 'largo' ); ?></option>
 				<option <?php selected( $instance['image_align'], 'right' ); ?> value="right"><?php esc_html_e( 'Right align', 'largo' ); ?></option>
 			</select>
@@ -214,7 +212,7 @@ class MStoday_Single_Post extends WP_Widget {
 
 		<p>
 			<label for="<?php echo esc_attr( $this->get_field_id( 'excerpt_display' ) ); ?>"><?php esc_html_e( 'Excerpt Display', 'largo' ); ?></label>
-			<select id="<?php echo esc_attr( $this->get_field_id( 'excerpt_display' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'excerpt_display' ) ); ?>" class="widefat" style="width:90%;">
+			<select id="<?php echo esc_attr( $this->get_field_id( 'excerpt_display' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'excerpt_display' ) ); ?>" class="widefat" style="">
 				<option <?php selected( $instance['excerpt_display'], 'num_sentences' ); ?> value="num_sentences"><?php esc_html_e( 'Use # of Sentences', 'largo' ); ?></option>
 				<option <?php selected( $instance['excerpt_display'], 'custom_excerpt' ); ?> value="custom_excerpt"><?php esc_html_e( 'Use Custom Post Excerpt', 'largo' ); ?></option>
 				<option <?php selected( $instance['excerpt_display'], 'none' ); ?> value="none"><?php esc_html_e( 'None', 'largo' ); ?></option>
@@ -223,7 +221,7 @@ class MStoday_Single_Post extends WP_Widget {
 
 		<p>
 			<label for="<?php echo esc_attr( $this->get_field_id( 'num_sentences' ) ); ?>"><?php esc_html_e( 'Excerpt Length (# of Sentences):', 'largo' ); ?></label>
-			<input id="<?php echo esc_attr( $this->get_field_id( 'num_sentences' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'num_sentences' ) ); ?>" value="<?php echo (int) $instance['num_sentences']; ?>" style="width:90%;" type="number" min="0"/>
+			<input id="<?php echo esc_attr( $this->get_field_id( 'num_sentences' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'num_sentences' ) ); ?>" value="<?php echo (int) $instance['num_sentences']; ?>" style="" type="number" min="0"/>
 		</p>
 
 		<p>

--- a/wp-content/themes/mstoday/inc/widget-single-post.php
+++ b/wp-content/themes/mstoday/inc/widget-single-post.php
@@ -124,7 +124,7 @@ class MStoday_Single_Post extends WP_Widget {
 		echo '</ul>';
 
 		if ( ! empty( $instance['linkurl'] ) && ! empty( $instance['linktext'] ) ) {
-			echo '<p class="morelink btn btn-primary"><a href="' . esc_url( $instance['linkurl'] ) . '">' . esc_html( $instance['linktext'] ) . '</a></p>';
+			echo '<p class="morelink"><a href="' . esc_url( $instance['linkurl'] ) . '">' . esc_html( $instance['linktext'] ) . '</a></p>';
 		}
 
 		// close the widget

--- a/wp-content/themes/mstoday/inc/widget-single-post.php
+++ b/wp-content/themes/mstoday/inc/widget-single-post.php
@@ -1,0 +1,201 @@
+<?php
+/**
+ * Single Post widget
+ *
+ * Displays a single post using the same template as Largo Recent Posts.
+ *
+ * @link https://github.com/INN/umbrella-mstoday/issues/72
+ */
+
+/**
+ * The Borderzine 3-Column recent posts widget
+ *
+ * Copied from Largo Recent Posts
+ */
+class Borderzine_3_Col_Widget extends WP_Widget {
+
+	/**
+	 * Register widget with WordPress.
+	 */
+	public function __construct() {
+
+		$widget_ops = array(
+			'classname' => 'mstoday-single-post',
+			'description' => __( 'Displays a single post.', 'mstoday' ),
+		);
+		parent::__construct(
+			'mstoday-single-post', // Base ID
+			__( 'Mississippi Today Single Post', 'mstoday' ), // Name
+			$widget_ops // Args
+		);
+
+	}
+
+	/**
+	 * Outputs the content of the recent posts widget.
+	 *
+	 * @param array $args widget arguments.
+	 * @param array $instance saved values from databse.
+	 * @global $post
+	 * @global $shown_ids An array of post IDs already on the page, to avoid duplicating posts
+	 * @global $wp_query Used to get posts on the page not in $shown_ids, to avoid duplicating posts
+	 */
+	public function widget( $args, $instance ) {
+
+		global $post,
+			$wp_query, // grab this to copy posts in the main column
+			$shown_ids; // an array of post IDs already on a page so we can avoid duplicating posts;
+
+		// Preserve global $post
+		$preserve = $post;
+
+
+		// Add the link to the title.
+		$title = apply_filters( 'widget_title', empty( $instance['title'] ) ? '' : $instance['title'], $instance, $this->id_base );
+
+		$thumb = isset( $instance['thumbnail_display'] ) ? $instance['thumbnail_display'] : 'small';
+		$excerpt = isset( $instance['excerpt_display'] ) ? $instance['excerpt_display'] : 'num_sentences';
+
+		$query_args = array (
+			'posts_per_page' => isset( $instance['num_posts'] ) ? $instance['num_posts'] : 3,
+			'post_status'    => 'publish',
+			'tax_query'      => array(),
+		);
+
+		if ( isset( $instance['avoid_duplicates'] ) && 1 === $instance['avoid_duplicates'] ) {
+			$query_args['post__not_in'] = $shown_ids;
+		}
+		if ( ! empty( $instance['cat'] ) ) {
+			$query_args['cat'] = $instance['cat'];
+		}
+		if ( ! empty( $instance['tag'] ) ) {
+			$query_args['tag'] = $instance['tag'];
+		}
+		if ( ! empty( $instance['author'] ) ) {
+			$query_args['author'] = $instance['author'];
+		}
+		if ( ! empty( $instance['prominence'] ) ) {
+			$query_args['tax_query'] = array_merge(
+				$query_args['tax_query'],
+				array(
+					array(
+						'taxonomy' => 'prominence',
+						'field'    => 'term_id',
+						'terms'    => $instance['prominence'],
+					),
+				)
+			);
+		}
+
+		/*
+		 * here begins the widget output
+		 */
+
+		echo wp_kses_post( $args['before_widget'] );
+
+		if ( ! empty( $title ) ) {
+			echo $args['before_title'] . wp_kses_post( $title ). $args['after_title'];
+		}
+
+		if ( ! empty( $instance['linkurl'] ) && ! empty( $instance['linktext'] ) ) {
+			echo '<p class="morelink btn btn-primary"><a href="' . esc_url( $instance['linkurl'] ) . '">' . esc_html( $instance['linktext'] ) . '</a></p>';
+		}
+
+		echo '<ul>';
+
+		$my_query = new WP_Query( $query_args );
+
+		if ( $my_query->have_posts() ) {
+
+			$output = '';
+
+			while ( $my_query->have_posts() ) {
+				$my_query->the_post();
+				$shown_ids[] = get_the_ID();
+
+				// wrap the items in li's.
+				$output .= sprintf(
+					'<li class="%1$s" >',
+					implode( ' ', get_post_class( '', get_the_id() ) )
+				);
+
+				$context = array(
+					'instance' => $instance,
+					'thumb' => $thumb,
+					'excerpt' => $excerpt,
+				);
+
+				ob_start();
+				largo_render_template( 'partials/widget', 'content', $context );
+				$output .= ob_get_clean();
+
+				// close the item
+				$output .= '</li>';
+
+			} // endwhile.
+
+			// print all of the items
+			echo $output;
+
+		} else {
+			printf(
+				'<p class="error"><strong>%1$s</strong></p>',
+				sprintf(
+					// translators: %s is the word this site uses for "posts", like "articles" or "stories". It's a plural noun.
+					esc_html__( 'You don\'t have any recent %s', 'largo' ),
+					of_get_option( 'posts_term_plural', 'Posts' )
+				)
+			);
+		} // end more featured posts
+
+		// close the ul
+		echo '</ul>';
+
+		// close the widget
+		echo wp_kses_post( $args['after_widget'] );
+
+		// Restore global $post
+		wp_reset_postdata();
+		$post = $preserve;
+	}
+
+	public function update( $new_instance, $old_instance ) {
+		$instance = $old_instance;
+		$instance['title'] = sanitize_text_field( $new_instance['title'] );
+		$instance['post_id'] = (int) sanitize_text_field( $new_instance['post_id'] ); // a number
+		return $instance;
+	}
+
+	public function form( $instance ) {
+		$defaults = array(
+			'title' => sprintf(
+				// translators: %s is the word this site uses for "posts", like "articles" or "stories". It's a plural noun.
+				__( 'Recent %1$s' , 'largo' ),
+				of_get_option( 'posts_term_plural', 'Posts' )
+			),
+			'post_id' => null,
+		);
+		$instance = wp_parse_args( (array) $instance, $defaults );
+
+		?>
+
+		<p>
+			<label for="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>"><?php esc_html_e( 'Title:', 'largo' ); ?></label>
+			<input id="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'title' ) ); ?>" value="<?php echo esc_attr( $instance['title'] ); ?>" style="width:90%;" type="text" />
+		</p>
+
+		<p>
+			<label for="<?php echo esc_attr( $this->get_field_id( 'post_id' ) ); ?>"><?php esc_html_e( 'ID of post to show:', 'mstoday' ); ?></label>
+			<input id="<?php echo esc_attr( $this->get_field_id( 'post_id' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'post_id' ) ); ?>" value="<?php echo esc_attr( $instance['post_id'] ); ?>" style="width:90%;" type="number" />
+		</p>
+
+		<?php
+	}
+}
+
+/**
+ * Register the widget
+ */
+add_action( 'widgets_init', function() {
+	register_widget( 'Borderzine_3_Col_Widget' );
+});

--- a/wp-content/themes/mstoday/partials/widget-content.php
+++ b/wp-content/themes/mstoday/partials/widget-content.php
@@ -1,0 +1,59 @@
+<?php
+
+// The top term
+if ( isset( $instance['show_top_term'] ) && $instance['show_top_term'] == 1 && largo_has_categories_or_tags() ) {
+	largo_maybe_top_term();
+}
+
+
+// the thumbnail image (if we're using one)
+if ($thumb == 'small') {
+	$img_location = ! empty( $instance['image_align'] ) ? $instance['image_align'] : 'left';
+	$img_attr = array( 'class' => $img_location . '-align' );
+	$img_attr['class'] .= " attachment-small";
+	?>
+		<a href="<?php echo get_permalink(); ?>"><?php echo get_the_post_thumbnail( get_the_ID(), '60x60', $img_attr); ?></a>
+	<?php
+} elseif ($thumb == 'medium') {
+	$img_location = ! empty( $instance['image_align'] ) ? $instance['image_align'] : 'left';
+	$img_attr = array('class' => $img_location . '-align');
+	$img_attr['class'] .= " attachment-thumbnail";
+	?>
+		<a href="<?php echo get_permalink(); ?>"><?php echo get_the_post_thumbnail( get_the_ID(), 'post-thumbnail', $img_attr); ?></a>
+	<?php
+} elseif ($thumb == 'large') {
+	$img_attr = array();
+	$img_attr['class'] = " attachment-large";
+	?>
+		<a href="<?php echo get_permalink(); ?>"><?php echo get_the_post_thumbnail( get_the_ID(), 'large', $img_attr); ?></a>
+	<?php
+}
+
+// the headline and optionally the post-type icon
+?><h5>
+	<a href="<?php echo get_permalink(); ?>"><?php echo get_the_title(); ?>
+	<?php
+		if ( isset( $instance['show_icon'] ) && $instance['show_icon'] == true ) {
+			post_type_icon();
+		}
+	?>
+	</a>
+</h5>
+
+<?php // byline on posts
+if ( isset( $instance['show_byline'] ) && $instance['show_byline'] == true) {
+	$hide_byline_date = ( isset( $instance['hide_byline_date'] ) ) ? $instance['hide_byline_date'] : false;
+	?>
+		<span class="byline"><?php echo largo_byline( false, $hide_byline_date, get_the_ID() ); ?></span>
+	<?php
+}
+
+// the excerpt
+if ( $excerpt == 'num_sentences' ) {
+	$num_sentences = ( ! empty( $instance['num_sentences'] ) ) ? $instance['num_sentences'] : 2;
+	?>
+		<p><?php echo largo_trim_sentences( get_the_content(), $num_sentences ); ?></p>
+	<?php } elseif ( $excerpt == 'custom_excerpt' ) { ?>
+		<p><?php echo get_the_excerpt(); ?></p>
+	<?php
+}


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Adds a MS Today Single Post widget, which displays a single post by ID.
- Fixes the "circular" call described in https://developer.wordpress.org/reference/functions/is_main_query/#under-the-hood that was affecting a filter on the `pre_get_posts` action, since I saw that in the debug log:
    > [25-Mar-2020 21:00:30 UTC] PHP Notice:  is_main_query was called <strong>incorrectly</strong>. In <code>pre_get_posts</code>, use the <code>WP_Query->is_main_query()</code> method, not the <code>is_main_query()</code> function. See https://codex.wordpress.org/Function_Reference/is_main_query. Please see <a href="https://wordpress.org/support/article/debugging-in-wordpress/">Debugging in WordPress</a> for more information. (This message was added in version 3.7.0.) in /Users/blk/sites/mstoday/wp-includes/functions.php on line 4986
- Copies in Largo's `partials/widget-content.php` to fix https://github.com/INN/largo/issues/1855 so that the byline date can be unhidden

Widget admin:

![Screen Shot 2020-03-25 at 19 08 43](https://user-images.githubusercontent.com/1754187/77594132-13099400-6ecc-11ea-9a90-250b86fc0fe5.png)

Comparison of styles of the Single Post widget and Largo Recent Posts:

![Screen Shot 2020-03-25 at 19 10 02](https://user-images.githubusercontent.com/1754187/77594189-4a784080-6ecc-11ea-97af-b17eab2e5b09.png)


## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For #72, and to make sure that they can enable the date on posts using this code.

## Testing/Questions

Features that this PR affects:

- The `pre_get_posts` fix affects the categories `around-the-state` and `mississippi-roundup`. These two categories, and no others, should not display the featured posts section at the top of the category archive
- All Largo Recent Posts widgets, and anything else that uses `partials/widget-content.php` 

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [ ] Is this PR targeting the correct branch in this repository?
- [ ] Do we need a better UI than inserting a raw post ID?
- [ ] Does there need to be better descriptive language regarding the post ID?
- [x] Do we need to remove the `btn btn-primary` classes from the optional "more" link?
- [ ] Which widget areas does this need to be tested in?

Steps to test this PR:

0. Check out this branch.
1. Insert a MS Today Single Post widget in a widget area somewhere.
2. Feed it a post ID and save the widget.
3. Verify that the widget displays.
4. Verify that all the widget options work.
5. Switch back to `master` and review the various Largo Recent Posts widgets on the site. Switch back to this branch. The presence or absence of the date in bylines should be unchanged.