### PR TITLE
Dequeue inline google spreadsheet viewer plugin assets

### DIFF
--- a/wp-content/themes/mstoday/functions.php
+++ b/wp-content/themes/mstoday/functions.php
@@ -387,3 +387,63 @@ function mstoday_rocket_load_ignored_scripts( $tag, $handle, $src ) {
 	
 }
 add_filter( 'script_loader_tag', 'mstoday_rocket_load_ignored_scripts', 10, 3 );
+
+/**
+ * Conditionally enqueue all of the required JS and CSS for the Inline Google Spreadsheet Viewer plugin
+ * in order to help with pagespeed and performance. Now these assets should only be loaded on posts or pages
+ * that contain the [gdoc] shortcode.
+ * 
+ * @see https://github.com/INN/umbrella-mstoday/issues/95
+ * @see https://wordpress.org/support/topic/page-load-performance-issues-solution-suggestion/
+ */
+function mstoday_dequeue_unused_google_inline_sheets_assets() {
+
+	global $post;
+	
+	$maybe_load_assets = false;
+
+	$scripts = array(
+		'jquery-datatables',
+		'datatables-buttons',
+		'datatables-buttons-colvis',
+		'datatables-buttons-print',
+		'datatables-buttons-html5',
+		'datatables-fixedheader',
+		'datatables-fixedcolumns',
+		'datatables-responsive',
+		'datatables-select',
+		'igsv-datatables',
+		'google-ajax-api',
+		'igsv-gvizcharts',
+		'pdfmake',
+		'pdfmake-fonts',
+		'vfs-fonts',
+		'jszip'
+	);
+	
+	$styles = array(
+		'jquery-datatables',
+		'datatables-buttons',
+		'datatables-select',
+		'datatables-fixedheader',
+		'datatables-fixedcolumns',
+		'datatables-responsive'
+	);
+
+	if( is_single() || is_page() && has_shortcode( $post->post_content, 'gdoc' ) ) {
+		$maybe_load_assets = true;
+		return;
+	}
+
+	if( false == $maybe_load_assets ) {
+		foreach( $scripts as $script ) {
+			wp_dequeue_script( $script );
+		}
+
+		foreach( $styles as $style ) {
+			wp_dequeue_style( $style );
+		}
+	}
+
+}
+add_filter( 'wp_enqueue_scripts', 'mstoday_dequeue_unused_google_inline_sheets_assets', 9999 );

--- a/wp-content/themes/mstoday/functions.php
+++ b/wp-content/themes/mstoday/functions.php
@@ -430,7 +430,7 @@ function mstoday_dequeue_unused_google_inline_sheets_assets() {
 		'datatables-responsive'
 	);
 
-	if( is_single() || is_page() && has_shortcode( $post->post_content, 'gdoc' ) ) {
+	if( ( is_single() || is_page() ) && has_shortcode( $post->post_content, 'gdoc' ) ) {
 		$maybe_load_assets = true;
 		return;
 	}


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Creates a function that hooks into the `wp_enqueue_scripts` filter and dequeues JS + CSS from the Inline Google Spreadsheet Viewer plugin if:
    - the user is not on a single page
    - the user is not on a single post
    - the single page or post that the user is on does not contain the `gdoc` shortcode

Styles that are dequeued:
- 'jquery-datatables',
- 'datatables-buttons',
- 'datatables-select',
- 'datatables-fixedheader',
- 'datatables-fixedcolumns',
- 'datatables-responsive'

Scripts that are dequeued:
- 'jquery-datatables',
- 'datatables-buttons',
- 'datatables-buttons-colvis',
- 'datatables-buttons-print',
- 'datatables-buttons-html5',
- 'datatables-fixedheader',
- 'datatables-fixedcolumns',
- 'datatables-responsive',
- 'datatables-select',
- 'igsv-datatables',
- 'google-ajax-api',
- 'igsv-gvizcharts',
- 'pdfmake',
- 'pdfmake-fonts',
- 'vfs-fonts',
- 'jszip'

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For #95 

## Testing/Questions

Features that this PR affects:

- The entirety of the site, but mainly posts or pages using the `gdoc` shortcode

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [x] Is this PR targeting the correct branch in this repository?
- [x] Is there a better filter to use than `wp_enqueue_scripts`?
- [x] I know `$maybe_load_assets` doesn't really do anything of value here, but it makes me feel better having it in there in case we ever expand this function

Steps to test this PR:

1. Load a few parts of the site that are not single posts or pages and make sure none of the CSS or JS is being loaded that shouldn't be
2. Load a single post and page without the `gdoc` shortcode and make sure none of the CSS or JS is being loaded
3. Load a single post and page with the `gdoc` shortcode (try post `92034`) and make sure the assets load correctly and the inline spreadsheet viewer works as expected