### PR TITLE
Reduce image sizes on homepage

### DIFF
--- a/wp-content/themes/mstoday/homepages/zones/mstoday-zones.php
+++ b/wp-content/themes/mstoday/homepages/zones/mstoday-zones.php
@@ -5,7 +5,7 @@ function zone_homepage_top_story() {
 	$topstory = largo_home_single_top();
 
 	$shown_ids[] = $topstory->ID;
-	$thumbnail = get_the_post_thumbnail( $topstory->ID, 'full' );
+	$thumbnail = get_the_post_thumbnail( $topstory->ID, 'large' );
 	$excerpt = largo_excerpt( $topstory, 2, false, '', false );
 
 	ob_start(); ?>
@@ -84,7 +84,7 @@ function zone_homepage_second_story() {
 	}
 	foreach ( $featured_stories as $featured ) {
 		$shown_ids[] = $featured->ID;
-		$thumbnail = get_the_post_thumbnail( $featured->ID, 'rect_thumb' ); 
+		$thumbnail = get_the_post_thumbnail( $featured->ID, 'rect_thumb_half' );
 		$excerpt = largo_excerpt( $featured, 2, false, '', false );
 	?>
 		<div class="span4">


### PR DESCRIPTION


## Changes

This pull request makes the following changes:

- Homepage top image goes from 1170px wide to 771px wide. Its maximum displayed width is 646px at 680px viewport width.
- Homepage featured images go from 800px 4:3 to 400px 4:3. Their maximum displayed width is 246px at above 1170px viewport width.


## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For https://github.com/INN/umbrella-mstoday/issues/87, based on research in https://github.com/INN/umbrella-mstoday/issues/86

## Testing/Questions

Features that this PR affects:

- Homepage

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [x] Is this PR targeting the correct branch in this repository?
- [ ] 

Steps to test this PR:

1. Compare page load sizes between `staging` and this branch.