### PR TITLE
Dequeue siteorigin scripts and styles on non-SO pages

### DIFF
--- a/wp-content/themes/mstoday/functions.php
+++ b/wp-content/themes/mstoday/functions.php
@@ -492,8 +492,10 @@ function mstoday_dequeue_unused_site_origin_assets() {
 	$uploads_dir = wp_upload_dir();
 	$siteorigin_uploads = $uploads_dir['basedir'] . '/siteorigin-widgets';
 	$uploads_items = list_files( $siteorigin_uploads, 1 );
-	foreach ( $uploads_items as $item ) {
-		$styles[] = str_replace( '.css', '', basename( $item ) );
+	if( ! empty( $uploads_items ) ) {
+		foreach ( $uploads_items as $item ) {
+			$styles[] = str_replace( '.css', '', basename( $item ) );
+		}
 	}
 
 	if( false == $maybe_load_assets ) {

--- a/wp-content/themes/mstoday/functions.php
+++ b/wp-content/themes/mstoday/functions.php
@@ -430,7 +430,7 @@ function mstoday_dequeue_unused_google_inline_sheets_assets() {
 		'datatables-responsive'
 	);
 
-	if( ( is_single() || is_page() ) && has_shortcode( $post->post_content, 'gdoc' ) ) {
+	if( ( is_single() || is_page() ) && is_a( $post, 'WP_Post' ) && has_shortcode( $post->post_content, 'gdoc' ) ) {
 		$maybe_load_assets = true;
 		return;
 	}
@@ -463,7 +463,7 @@ function mstoday_dequeue_unused_site_origin_assets() {
 
 	$maybe_load_assets = false;
 
-	if ( ( is_single() || is_page() ) && siteorigin_panels_render( $post->ID ) ){
+	if ( ( is_single() || is_page() ) && is_a( $post, 'WP_Post' ) && siteorigin_panels_render( $post->ID ) ){
 		$maybe_load_assets = true;
 		return;
 	}
@@ -487,18 +487,18 @@ function mstoday_dequeue_unused_site_origin_assets() {
 		'sow-cta-main'
 	);
 
-	// loop through /uploads/siteorigin-widgets/* and remove all of those css files
-	// because for some reason the SO widgets bundle plugin creates these files based off of widget settigns
-	$uploads_dir = wp_upload_dir();
-	$siteorigin_uploads = $uploads_dir['basedir'] . '/siteorigin-widgets';
-	$uploads_items = list_files( $siteorigin_uploads, 1 );
-	if( ! empty( $uploads_items ) ) {
-		foreach ( $uploads_items as $item ) {
-			$styles[] = str_replace( '.css', '', basename( $item ) );
+	if( false === $maybe_load_assets ) {
+		// loop through /uploads/siteorigin-widgets/* and remove all of those css files
+		// because for some reason the SO widgets bundle plugin creates these files based off of widget settigns
+		$uploads_dir = wp_upload_dir();
+		$siteorigin_uploads = $uploads_dir['basedir'] . '/siteorigin-widgets';
+		$uploads_items = list_files( $siteorigin_uploads, 1 );
+		if( ! empty( $uploads_items ) ) {
+			foreach ( $uploads_items as $item ) {
+				$styles[] = str_replace( '.css', '', basename( $item ) );
+			}
 		}
-	}
 
-	if( false == $maybe_load_assets ) {
 		foreach( $scripts as $script ) {
 			wp_dequeue_script( $script );
 		}

--- a/wp-content/themes/mstoday/functions.php
+++ b/wp-content/themes/mstoday/functions.php
@@ -447,3 +447,64 @@ function mstoday_dequeue_unused_google_inline_sheets_assets() {
 
 }
 add_filter( 'wp_enqueue_scripts', 'mstoday_dequeue_unused_google_inline_sheets_assets', 9999 );
+
+/**
+ * Conditionally enqueue all of the required JS and CSS for the SiteOrigin page builder plugin + its addons
+ * in order to help with pagespeed and performance. Now these assets should only be loaded on posts or pages
+ * where `siteorigin_panels_render( $post->ID )` isn't empty.
+ * 
+ * @see https://github.com/INN/umbrella-mstoday/issues/95
+ * @see https://siteorigin.com/docs/widgets-bundle/form-building/builder-field/
+ * @see https://siteorigin.com/thread/check-if-page-is-using-the-page-builder/
+ */
+function mstoday_dequeue_unused_site_origin_assets() {
+
+	global $post;
+
+	$maybe_load_assets = false;
+
+	if ( ( is_single() || is_page() ) && siteorigin_panels_render( $post->ID ) ){
+		$maybe_load_assets = true;
+		return;
+	}
+
+	$scripts = array(
+		'siteorigin-premium-web-font-importer',
+		'sow-slider-slider-cycle2',
+		'sow-slider-slider-cycle2-swipe',
+		'sow-google-map',
+		'sow-slider-slider',
+		'sowb-fittext',
+		'sow-cta-main'
+	);
+
+	$styles = array(
+		'sow-slider-slider-cycle2',
+		'sow-slider-slider-cycle2-swipe',
+		'sow-google-map',
+		'sow-slider-slider',
+		'sow-button-base',
+		'sow-cta-main'
+	);
+
+	// loop through /uploads/siteorigin-widgets/* and remove all of those css files
+	// because for some reason the SO widgets bundle plugin creates these files based off of widget settigns
+	$uploads_dir = wp_upload_dir();
+	$siteorigin_uploads = $uploads_dir['basedir'] . '/siteorigin-widgets';
+	$uploads_items = list_files( $siteorigin_uploads, 1 );
+	foreach ( $uploads_items as $item ) {
+		$styles[] = str_replace( '.css', '', basename( $item ) );
+	}
+
+	if( false == $maybe_load_assets ) {
+		foreach( $scripts as $script ) {
+			wp_dequeue_script( $script );
+		}
+
+		foreach( $styles as $style ) {
+			wp_dequeue_style( $style );
+		}
+	}
+
+}
+add_filter( 'wp_enqueue_scripts', 'mstoday_dequeue_unused_site_origin_assets', 9999999 );


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Creates a function that hooks into the wp_enqueue_scripts filter and dequeues JS + CSS from the Site Origin page builder plugin + its addons if:
   - the user is not on a single page
   - the user is not on a single post
   - the single page or post that the user is on does not return anything from `siteorigin_panels_render( $post->ID )`

Styles that are dequeued:
- 'sow-slider-slider-cycle2',
- 'sow-slider-slider-cycle2-swipe',
- 'sow-google-map',
- 'sow-slider-slider',
- 'sow-button-base',
- 'sow-cta-main'
- any file inside of `/uploads/siteorigin-widgets/`

Scripts that are dequeued:
- 'siteorigin-premium-web-font-importer',
- 'sow-slider-slider-cycle2',
- 'sow-slider-slider-cycle2-swipe',
- 'sow-google-map',
- 'sow-slider-slider',
- 'sowb-fittext',
- 'sow-cta-main'

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For #95

## Testing/Questions

Features that this PR affects:

- The entire site, but mainly posts or pages using the SO builder

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [x] Is this PR targeting the correct branch in this repository?
- [ ] Any security (or more general) concerns about the way of finding files inside of the `uploads` directory to dequeue?

Steps to test this PR:

1. Load a few parts of the site that are not single posts or pages and make sure none of the CSS or JS is being loaded that shouldn't be
2. Load a single post and page without the page builder enabled and make sure none of the CSS or JS is being loaded
- Load a single post and page with the page builder enabled (try page `501083`) and make sure the assets load correctly and the page builder elements work as expected