### PR TITLE
Register sticky-nav menu, remove global nav from sticky menu

### DIFF
--- a/wp-content/themes/mstoday/functions.php
+++ b/wp-content/themes/mstoday/functions.php
@@ -387,3 +387,19 @@ function mstoday_rocket_load_ignored_scripts( $tag, $handle, $src ) {
 	
 }
 add_filter( 'script_loader_tag', 'mstoday_rocket_load_ignored_scripts', 10, 3 );
+
+/**
+ * Register child theme specific nav menus for MS Today child theme
+ * 
+ * @see https://github.com/INN/umbrella-mstoday/issues/91#issuecomment-658402245
+ */
+function mstoday_register_custom_nav_menus() {
+
+	$menus = array(
+		'sticky-nav' => __( 'Sticky Navigation', 'mstoday' )
+	);
+
+	register_nav_menus( $menus );
+
+}
+add_action( 'init', 'mstoday_register_custom_nav_menus' );

--- a/wp-content/themes/mstoday/partials/nav-sticky.php
+++ b/wp-content/themes/mstoday/partials/nav-sticky.php
@@ -136,7 +136,7 @@ $site_name = ( of_get_option( 'nav_alt_site_name', false ) ) ? of_get_option( 'n
 
 							/* Build Main Navigation using Boostrap_Walker_Nav_Menu() */
 							$args = array(
-								'theme_location' => 'main-nav',
+								'theme_location' => 'sticky-nav',
 								'depth'		 => 0,
 								'container'	 => false,
 								'items_wrap' => '%3$s',
@@ -154,29 +154,7 @@ $site_name = ( of_get_option( 'nav_alt_site_name', false ) ) ? of_get_option( 'n
 								</li><?php
 								}
 							}
-							if (has_nav_menu('global-nav')) {
-								$args = array(
-									'theme_location' => 'global-nav',
-									'depth'		 => 1,
-									'container'	 => false,
-									'menu_class' => 'dropdown-menu',
-									'echo' => false
-								);
-								$global_nav = largo_nav_menu($args);
-
-								if (!empty($global_nav)) { ?>
-									<li class="menu-item menu-item-has-childen dropdown">
-										<a href="javascript:void(0);" class="dropdown-toggle"><?php
-											//try to get the menu name from global-nav
-											$menus = get_nav_menu_locations();
-											$menu_title = wp_get_nav_menu_object($menus['global-nav'])->name;
-											echo ( $menu_title ) ? $menu_title : __('About', 'largo');
-											?> <b class="caret"></b>
-										</a>
-										<?php echo $global_nav; ?>
-									</li>
-								<?php } ?>
-							<?php } ?>
+							?>
 						</ul>
 					</div>
 				</div>


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Registers a new `sticky-nav` menu location
- Replaces `main-nav` with `sticky-nav` in `partials/nav-sticky.php`
- Removes the global nav from `partials/nav-sticky.php`

All described in https://github.com/INN/umbrella-mstoday/issues/91#issuecomment-658402245

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For #91

## Testing/Questions

Features that this PR affects:

- Sticky and mobile menus

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [x] Is this PR targeting the correct branch in this repository?
- [x] Is `Sticky Navigation` and ok name for this menu, or should it be something else?

Steps to test this PR:

1. Add a menu to the new sticky nav menu location and make sure it works as expected